### PR TITLE
Update spec file requirements

### DIFF
--- a/packaging/rpm/cookbook-rb-aioutliers.spec
+++ b/packaging/rpm/cookbook-rb-aioutliers.spec
@@ -5,6 +5,7 @@ Release:  %{__release}%{?dist}
 License:  GNU AGPLv3
 URL:  https://github.com/redBorder/cookbook-rb-aioutliers
 Source0: %{name}-%{version}.tar.gz
+Requires: rb-aioutliers
 
 Summary: rbaioutliers cookbook to install and configure it in redborder environments
 
@@ -48,5 +49,7 @@ systemctl daemon-reload
 %doc
 
 %changelog
+* Thu Sep 26 2023 - Miguel Álvarez <malvarez@redborder.com> - 0.0.2-1
+- Update requirements of the cookbook
 * Mon Sep 25 2023 - Miguel Álvarez <malvarez@redborder.com> - 0.0.1-1
 - Initial spec version

--- a/resources/metadata.rb
+++ b/resources/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'malvarez@redborder.com'
 license          'All rights reserved'
 description      'Installs/Configures cookbook-rb-aioutliers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.0.1'
+version          '0.0.2'


### PR DESCRIPTION
rb-aioutliers is needed as a requirement to install the rb-aioutliers service after installing his cookbook